### PR TITLE
Update node to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     description: 'Include prefix (or not) on conversion. True by default'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: book-open


### PR DESCRIPTION
Node 16 GA actions are deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/