### PR TITLE
Added option to convert secrets to base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
-  - uses: oNaiPs/secrets-to-env-action@v1
-    with:
-      secrets: ${{ toJSON(secrets) }}
-      prefix: PREFIX_
-      convert: lower
-      convert_prefix: false
-  - run: env
+- uses: actions/checkout@v3
+- uses: oNaiPs/secrets-to-env-action@v1
+  with:
+    secrets: ${{ toJSON(secrets) }}
+    prefix: PREFIX_
+    convert: lower
+    convert_prefix: false
+- run: env
 # E.g. secret with MY_SECRET would become PREFIX_my_secret
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Exclude defined secret(s) from list of secrets (comma separated, supports regex)
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
-  - uses: oNaiPs/secrets-to-env-action@v1
-    with:
-      secrets: ${{ toJSON(secrets) }}
-      exclude: MY_SECRET, MY_OTHER_SECRETS*
+- uses: actions/checkout@v3
+- uses: oNaiPs/secrets-to-env-action@v1
+  with:
+    secrets: ${{ toJSON(secrets) }}
+    exclude: MY_SECRET, MY_OTHER_SECRETS*
 # MY_SECRET is not exported
 ```
 
@@ -134,7 +134,7 @@ Value of MY_SECRET: DONT_OVERRIDE
 
 Converts all exported secrets according to a [template](https://github.com/blakeembrey/change-case#core).
 Available: `lower, upper, camel, constant, pascal, snake`.
-
+  
 ```yaml
 steps:
 - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Exclude defined secret(s) from list of secrets (comma separated, supports regex)
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
-- uses: oNaiPs/secrets-to-env-action@v1
-  with:
-    secrets: ${{ toJSON(secrets) }}
-    exclude: MY_SECRET, MY_OTHER_SECRETS*
+  - uses: actions/checkout@v3
+  - uses: oNaiPs/secrets-to-env-action@v1
+    with:
+      secrets: ${{ toJSON(secrets) }}
+      exclude: MY_SECRET, MY_OTHER_SECRETS*
 # MY_SECRET is not exported
 ```
 
@@ -134,7 +134,7 @@ Value of MY_SECRET: DONT_OVERRIDE
 
 Converts all exported secrets according to a [template](https://github.com/blakeembrey/change-case#core).
 Available: `lower, upper, camel, constant, pascal, snake`.
-  
+
 ```yaml
 steps:
 - uses: actions/checkout@v3
@@ -149,15 +149,27 @@ steps:
 
 ```yaml
 steps:
+  - uses: actions/checkout@v3
+  - uses: oNaiPs/secrets-to-env-action@v1
+    with:
+      secrets: ${{ toJSON(secrets) }}
+      prefix: PREFIX_
+      convert: lower
+      convert_prefix: false
+  - run: env
+# E.g. secret with MY_SECRET would become PREFIX_my_secret
+```
+
+**Converts all exported secrets to a base64 string (default is false):**
+
+```yaml
+steps:
 - uses: actions/checkout@v3
 - uses: oNaiPs/secrets-to-env-action@v1
   with:
     secrets: ${{ toJSON(secrets) }}
-    prefix: PREFIX_
-    convert: lower
-    convert_prefix: false
-- run: env
-# E.g. secret with MY_SECRET would become PREFIX_my_secret
+    value_as_base64: true
+- run: echo "Value of my_secret: $my_secret"
 ```
 
 ## How it works

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,7 +1,5 @@
-import * as cp from 'child_process'
-import * as path from 'path'
-import {expect, jest, test} from '@jest/globals'
 import * as core from '@actions/core'
+import {expect, jest} from '@jest/globals'
 import main from '../src/main'
 
 jest.mock('@actions/core')
@@ -18,6 +16,7 @@ function mockInputs(inputs: {[key: string]: string}) {
 
 describe('secrets-to-env-action', () => {
   let inputSecrets: {[key: string]: string}
+  let inputSecretsBase64: {[key: string]: string}
   let newSecrets: {[key: string]: string}
 
   beforeEach(() => {
@@ -25,6 +24,12 @@ describe('secrets-to-env-action', () => {
       MY_SECRET_1: 'VALUE_1',
       MY_SECRET_2: 'VALUE_2',
       my_low_secret_1: 'low_value_1'
+    }
+
+    inputSecretsBase64 = {
+      MY_SECRET_1: 'VkFMVUVfMQ==',
+      MY_SECRET_2: 'VkFMVUVfMg==',
+      my_low_secret_1: 'bG93X3ZhbHVlXzE='
     }
 
     newSecrets = {}
@@ -242,5 +247,15 @@ describe('secrets-to-env-action', () => {
     delete filteredNewSecrets.MY_SECRET_1
 
     expect(newSecrets).toEqual(filteredNewSecrets)
+  })
+
+  it('converts to base64', () => {
+    mockInputs({
+      secrets: JSON.stringify(inputSecrets),
+      value_as_base64: 'true'
+    })
+    main()
+
+    expect(newSecrets).toEqual(inputSecretsBase64)
   })
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,5 +1,7 @@
+import * as cp from 'child_process'
+import * as path from 'path'
+import {expect, jest, test} from '@jest/globals'
 import * as core from '@actions/core'
-import {expect, jest} from '@jest/globals'
 import main from '../src/main'
 
 jest.mock('@actions/core')

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Export all secrets to env variables'
-description: 'Utility action that exports all github secrets to environment variables'
-author: 'Jose Pereira @oNaiPs'
+name: 'Export all variables from other contexts to env variables'
+description: 'Utility action that exports all github secrets and vars to environment variables'
+author: 'Danilo Körber'
 inputs:
   secrets:
     required: true

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   override:
     required: false
     description: 'Either to override or not the variable if it already exists'
+  value_as_base64:
+    required: false
+    description: 'Either to convewrt or not the value to base64'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "camel-case": "^4.1.2",
     "constant-case": "^3.0.4",
     "pascal-case": "^3.1.2",
-    "snake-case": "^3.0.4"
+    "snake-case": "^3.0.4",
+    "universal-base64": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "camel-case": "^4.1.2",
     "constant-case": "^3.0.4",
     "pascal-case": "^3.1.2",
-    "snake-case": "^3.0.4",
-    "universal-base64": "^2.1.0"
+    "snake-case": "^3.0.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import {camelCase} from 'camel-case'
 import {constantCase} from 'constant-case'
 import {pascalCase} from 'pascal-case'
 import {snakeCase} from 'snake-case'
-import {encode} from 'universal-base64'
 
 const convertTypes: Record<string, (s: string) => string> = {
   lower: s => s.toLowerCase(),
@@ -104,7 +103,9 @@ with:
         }
       }
 
-      let newValue = valueAsBase64 ? encode(secrets[key]) : secrets[key]
+      let newValue = valueAsBase64
+        ? Buffer.from(secrets[key]).toString('base64')
+        : secrets[key]
 
       core.exportVariable(newKey, newValue)
       core.info(`Exported secret ${newKey}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {camelCase} from 'camel-case'
 import {constantCase} from 'constant-case'
 import {pascalCase} from 'pascal-case'
 import {snakeCase} from 'snake-case'
+import {encode} from 'universal-base64'
 
 const convertTypes: Record<string, (s: string) => string> = {
   lower: s => s.toLowerCase(),
@@ -34,6 +35,10 @@ export default async function run(): Promise<void> {
       : true
     const overrideStr: string = core.getInput('override')
     const override = overrideStr.length ? overrideStr === 'true' : true
+    const valueAsBase64Str: string = core.getInput('value_as_base64')
+    const valueAsBase64 = valueAsBase64Str.length
+      ? valueAsBase64Str === 'true'
+      : false
 
     let secrets: Record<string, string>
     try {
@@ -99,7 +104,9 @@ with:
         }
       }
 
-      core.exportVariable(newKey, secrets[key])
+      let newValue = valueAsBase64 ? encode(secrets[key]) : secrets[key]
+
+      core.exportVariable(newKey, newValue)
       core.info(`Exported secret ${newKey}`)
     }
   } catch (error) {


### PR DESCRIPTION
**Converts all exported secrets to a base64 string (default is false):**

```yaml
steps:
- uses: actions/checkout@v3
- uses: oNaiPs/secrets-to-env-action@v1
  with:
    secrets: ${{ toJSON(secrets) }}
    value_as_base64: true
- run: echo "Value of my_secret: $my_secret"
```

If `value_as_base64` is true, the value of the secret will be converted to a base64 string. 